### PR TITLE
Support nested unkeyed struct slices

### DIFF
--- a/_tests/nested-struct-slice-no-key.hcl
+++ b/_tests/nested-struct-slice-no-key.hcl
@@ -1,0 +1,7 @@
+Widget {
+  Foo = "bar"
+}
+
+Widget {
+  Foo = "baz"
+}

--- a/hclencoder_test.go
+++ b/hclencoder_test.go
@@ -104,6 +104,22 @@ func TestEncoder(t *testing.T) {
 			},
 			Output: "nested-struct-slice",
 		},
+		{
+			ID: "nested struct slice no key",
+			Input: struct {
+				Widget []struct {
+					Foo string
+				}
+			}{
+				Widget: []struct {
+					Foo string
+				}{
+					{"bar"},
+					{"baz"},
+				},
+			},
+			Output: "nested-struct-slice-no-key",
+		},
 	}
 
 	for _, test := range tests {
@@ -119,7 +135,11 @@ func TestEncoder(t *testing.T) {
 			}
 
 			assert.NoError(t, err, test.ID)
-			assert.EqualValues(t, string(expected), string(actual), test.ID+"\n"+string(actual))
+			assert.EqualValues(t,
+				string(expected),
+				string(actual),
+				fmt.Sprintf("%s\nExpected:\n%s\nActual:\n%s", test.ID, expected, actual),
+			)
 		}
 	}
 }

--- a/nodes.go
+++ b/nodes.go
@@ -258,9 +258,6 @@ func encodeStruct(in reflect.Value) (ast.Node, *ast.ObjectKey, error) {
 		// if the item is an object list, we need to flatten out the items
 		if val, ok := val.(*ast.ObjectList); ok {
 			for _, obj := range val.Items {
-				if len(obj.Keys) == 0 {
-					return nil, nil, errors.New("nested struct slice elements must have a key field")
-				}
 				keys := append([]*ast.ObjectKey{itemKey}, obj.Keys...)
 				list.Add(&ast.ObjectItem{
 					Keys: keys,

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -349,8 +349,18 @@ func TestEncodeStruct(t *testing.T) {
 		},
 		{
 			ID:    "nested unkeyed struct slice",
-			Input: reflect.ValueOf(struct{ Foo []TestStruct }{[]TestStruct{{}}}),
-			Error: true,
+			Input: reflect.ValueOf(struct{ Foo []TestStruct }{[]TestStruct{{"Test"}}}),
+			Expected: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+				&ast.ObjectItem{
+					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Foo"}}},
+					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+						&ast.ObjectItem{
+							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
+							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"Test"`}},
+						},
+					}}},
+				},
+			}}},
 		},
 	}
 


### PR DESCRIPTION
HCL supports this syntax for printing unkeyed struct slices:

```
node {
  hi = "there"
}

node {
  hi = "bob"
}
```

This diff removes the error case in hclencoder that prevented this.  I don't see why that error exists.  Possibly the HCL library did not support unkeyed struct slices when this library was written - but that doesn't seem to be the case anymore.