### PR TITLE
Keep single element list on one line

### DIFF
--- a/_tests/primitive-lists.hcl
+++ b/_tests/primitive-lists.hcl
@@ -9,3 +9,5 @@ Gizmos = [
   5,
   6,
 ]
+
+Single = ["foo"]

--- a/hclencoder_test.go
+++ b/hclencoder_test.go
@@ -53,9 +53,11 @@ func TestEncoder(t *testing.T) {
 			Input: struct {
 				Widgets []string
 				Gizmos  []int
+				Single  []string
 			}{
 				[]string{"foo", "bar", "baz"},
 				[]int{4, 5, 6},
+				[]string{"foo"},
 			},
 			Output: "primitive-lists",
 		},

--- a/walker.go
+++ b/walker.go
@@ -48,12 +48,16 @@ func positionNodes(node ast.Node, cur cursor, step int) (cursor, error) {
 
 	case *ast.ListType:
 		node.Lbrack = cur.pos()
-		cur = cur.crlf().in(step)
+		if len(node.List) > 1 {
+			cur = cur.crlf().in(step)
+		}
 		for _, item := range node.List {
 			if cur, err = positionNodes(item, cur, step); err != nil {
 				return cur, err
 			}
-			cur = cur.crlf()
+			if len(node.List) > 1 {
+				cur = cur.crlf()
+			}
 		}
 		cur = cur.out(step)
 		node.Rbrack = cur.pos()


### PR DESCRIPTION
Keep lists with a single element on one line.
Instead of 
```
datacenters = [
    "dc",
]
```
you get

```
datacenters = ["dc"]
```
