### PR TITLE
Add support for multiple keys

### DIFF
--- a/_tests/multiple-keys-nested-structs.hcl
+++ b/_tests/multiple-keys-nested-structs.hcl
@@ -1,0 +1,3 @@
+Foo "bar" "baz" {
+  Fizz = "buzz"
+}

--- a/example_test.go
+++ b/example_test.go
@@ -24,10 +24,17 @@ func Example() {
 		Sound string `hcl:"says" hcle:"omitempty"`
 	}
 
+	type Pet struct {
+		Species string `hcl:",key"`
+		Name    string `hcl:",key"`
+		Sound   string `hcl:"says" hcle:"omitempty"`
+	}
+
 	type Config struct {
 		Farm      `hcl:",squash"`
 		Farmer    Farmer            `hcl:"farmer"`
 		Animals   []Animal          `hcl:"animal"`
+		Pets      []Pet             `hcl:"pet"`
 		Buildings map[string]string `hcl:"buildings"`
 	}
 
@@ -53,6 +60,13 @@ func Example() {
 			},
 			{
 				Name: "rock",
+			},
+		},
+		Pets: []Pet{
+			{
+				Species: "cat",
+				Name:    "whiskers",
+				Sound:   "meow",
 			},
 		},
 		Buildings: map[string]string{
@@ -92,6 +106,10 @@ func Example() {
 	// }
 	//
 	// animal "rock" {}
+	//
+	// pet "cat" "whiskers" {
+	//   says = "meow"
+	// }
 	//
 	// buildings {
 	//   Barn  = "456 Digits Drive"

--- a/hclencoder_test.go
+++ b/hclencoder_test.go
@@ -91,6 +91,27 @@ func TestEncoder(t *testing.T) {
 			Output: "keyed-nested-structs",
 		},
 		{
+			ID: "multiple keys nested structs",
+			Input: struct {
+				Foo struct {
+					Key      string `hcl:",key"`
+					OtherKey string `hcl:",key"`
+					Fizz     string
+				}
+			}{
+				struct {
+					Key      string `hcl:",key"`
+					OtherKey string `hcl:",key"`
+					Fizz     string
+				}{
+					"bar",
+					"baz",
+					"buzz",
+				},
+			},
+			Output: "multiple-keys-nested-structs",
+		},
+		{
 			ID: "nested struct slice",
 			Input: struct {
 				Widget []struct {

--- a/nodes.go
+++ b/nodes.go
@@ -279,9 +279,9 @@ func encodeStruct(in reflect.Value) (ast.Node, []*ast.ObjectKey, error) {
 		// if the item is an object list, we need to flatten out the items
 		if val, ok := val.(*ast.ObjectList); ok {
 			for _, obj := range val.Items {
-				keys := append([]*ast.ObjectKey{itemKey}, obj.Keys...)
+				objectKeys := append([]*ast.ObjectKey{itemKey}, obj.Keys...)
 				list.Add(&ast.ObjectItem{
-					Keys: keys,
+					Keys: objectKeys,
 					Val:  obj.Val,
 				})
 			}

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -10,17 +10,17 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type encodeFunc func(reflect.Value) (ast.Node, *ast.ObjectKey, error)
+type encodeFunc func(reflect.Value) (ast.Node, []*ast.ObjectKey, error)
 
 type encodeTest struct {
 	ID       string
 	Input    reflect.Value
 	Expected ast.Node
-	Key      *ast.ObjectKey
+	Key      []*ast.ObjectKey
 	Error    bool
 }
 
-func (test encodeTest) Test(f encodeFunc, t *testing.T) (node ast.Node, key *ast.ObjectKey, err error) {
+func (test encodeTest) Test(f encodeFunc, t *testing.T) (node ast.Node, key []*ast.ObjectKey, err error) {
 	node, key, err = f(test.Input)
 
 	if test.Error {


### PR DESCRIPTION
At the moment, when having more than one `hcl:",key"`, one key overwrites the other. I would expect multiple keys to be possible to generate things that look like terraform resources. 

This PR fixes this issue. 