### PR TITLE
Fix encode map of slice

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -187,6 +187,20 @@ func encodeMap(in reflect.Value) (ast.Node, *ast.ObjectKey, error) {
 			continue
 		}
 
+		// If the item is an object list, we need to flatten out the items.
+		// Child keys are assumed to be added to the above call to encode
+		if val, ok := val.(*ast.ObjectList); ok {
+			itemKey := &ast.ObjectKey{Token: tkn}
+			for _, obj := range val.Items {
+				keys := append([]*ast.ObjectKey{itemKey}, obj.Keys...)
+				l = append(l, &ast.ObjectItem{
+					Keys: keys,
+					Val:  obj.Val,
+				})
+			}
+			continue
+		}
+
 		item := &ast.ObjectItem{
 			Keys: []*ast.ObjectKey{{Token: tkn}},
 			Val:  val,

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -278,6 +278,58 @@ func TestEncodeMap(t *testing.T) {
 				},
 			}}},
 		},
+		{
+			ID: "keyed list",
+			Input: reflect.ValueOf(map[string][]map[string]interface{}{
+				"obj1": []map[string]interface{}{
+					map[string]interface{}{"foo": "bar"},
+					map[string]interface{}{"boo": "hoo"},
+				},
+				"obj2": []map[string]interface{}{
+					map[string]interface{}{"foo": "bar"},
+					map[string]interface{}{"boo": "hoo"},
+				},
+			}),
+			Expected: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+				&ast.ObjectItem{
+					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj1"}}},
+					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+						&ast.ObjectItem{
+							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "boo"}}},
+							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"hoo"`}},
+						},
+					}}},
+				},
+				&ast.ObjectItem{
+					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj1"}}},
+					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+						&ast.ObjectItem{
+							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "foo"}}},
+							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"bar"`}},
+						},
+					}}},
+				},
+				&ast.ObjectItem{
+					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj2"}}},
+					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+						&ast.ObjectItem{
+							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "boo"}}},
+							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"hoo"`}},
+						},
+					}}},
+				},
+				&ast.ObjectItem{
+					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj2"}}},
+					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+						&ast.ObjectItem{
+							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "foo"}}},
+							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"bar"`}},
+						},
+					}}},
+				},
+			}},
+			},
+		},
 	}
 
 	RunAll(tests, encodeMap, t)


### PR DESCRIPTION
This adds support for a map containing non-primitive slices.  Example:
```
var m map[string][]map[string]interface{}
```

Currently trying to encode this results in invalid output and/or a panic on the hcl printer as the Key field
is missing due to it not being added when a map is encoded.