### PR TITLE
When a block list has no child key, assume it's a primitive list

### DIFF
--- a/_tests/nested-slices.hcl
+++ b/_tests/nested-slices.hcl
@@ -1,0 +1,10 @@
+bar = [
+  ["bar"],
+  ["baz"],
+  ["buzz"],
+]
+
+foo = [
+  "bar",
+  "baz",
+]

--- a/_tests/nested-struct-slice-no-key.hcl
+++ b/_tests/nested-struct-slice-no-key.hcl
@@ -1,7 +1,8 @@
-Widget {
-  Foo = "bar"
-}
-
-Widget {
-  Foo = "baz"
-}
+Widget = [
+  {
+    Foo = "bar"
+  },
+  {
+    Foo = "baz"
+  },
+]

--- a/hclencoder_test.go
+++ b/hclencoder_test.go
@@ -122,6 +122,26 @@ func TestEncoder(t *testing.T) {
 			},
 			Output: "nested-struct-slice-no-key",
 		},
+		{
+			ID: "nested slices",
+			Input: map[string]interface{}{
+				"foo": []interface{}{
+					"bar", "baz",
+				},
+				"bar": []interface{}{
+					[]interface{}{
+						"bar",
+					},
+					[]interface{}{
+						"baz",
+					},
+					[]interface{}{
+						"buzz",
+					},
+				},
+			},
+			Output: "nested-slices",
+		},
 	}
 
 	for _, test := range tests {

--- a/nodes.go
+++ b/nodes.go
@@ -157,11 +157,12 @@ func encodeBlockList(in reflect.Value) (ast.Node, *ast.ObjectKey, error) {
 		if child == nil {
 			continue
 		}
+		if childKey == nil {
+			return encodePrimitiveList(in)
+		}
 
 		item := &ast.ObjectItem{Val: child}
-		if childKey != nil {
-			item.Keys = []*ast.ObjectKey{childKey}
-		}
+		item.Keys = []*ast.ObjectKey{childKey}
 		n.Add(item)
 	}
 

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -166,17 +166,19 @@ func TestEncodeList(t *testing.T) {
 		{
 			ID:    "block",
 			Input: reflect.ValueOf([]TestStruct{{}, {Bar: "fizzbuzz"}}),
-			Expected: &ast.ObjectList{Items: []*ast.ObjectItem{
-				&ast.ObjectItem{Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-					&ast.ObjectItem{
+			Expected: &ast.ListType{List: []ast.Node{
+				&ast.ObjectType{List: &ast.ObjectList{
+					Items: []*ast.ObjectItem{{
 						Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `""`}}},
-				}}}},
-				&ast.ObjectItem{Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-					&ast.ObjectItem{
+						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `""`}},
+					}},
+				}},
+				&ast.ObjectType{List: &ast.ObjectList{
+					Items: []*ast.ObjectItem{{
 						Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"fizzbuzz"`}}},
-				}}}},
+						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"fizzbuzz"`}},
+					}},
+				}},
 			}},
 		},
 		{
@@ -187,33 +189,37 @@ func TestEncodeList(t *testing.T) {
 		{
 			ID:    "block - nil item",
 			Input: reflect.ValueOf([]*TestStruct{&TestStruct{}, nil, &TestStruct{Bar: "fizzbuzz"}}),
-			Expected: &ast.ObjectList{Items: []*ast.ObjectItem{
-				&ast.ObjectItem{Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-					&ast.ObjectItem{
+			Expected: &ast.ListType{List: []ast.Node{
+				&ast.ObjectType{List: &ast.ObjectList{
+					Items: []*ast.ObjectItem{{
 						Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `""`}}},
-				}}}},
-				&ast.ObjectItem{Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-					&ast.ObjectItem{
+						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `""`}},
+					}},
+				}},
+				&ast.ObjectType{List: &ast.ObjectList{
+					Items: []*ast.ObjectItem{{
 						Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"fizzbuzz"`}}},
-				}}}},
+						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"fizzbuzz"`}},
+					}},
+				}},
 			}},
 		},
 		{
 			ID:    "block - interface",
 			Input: reflect.ValueOf([]TestInterface{TestStruct{}, TestStruct{Bar: "fizzbuzz"}}),
-			Expected: &ast.ObjectList{Items: []*ast.ObjectItem{
-				&ast.ObjectItem{Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-					&ast.ObjectItem{
+			Expected: &ast.ListType{List: []ast.Node{
+				&ast.ObjectType{List: &ast.ObjectList{
+					Items: []*ast.ObjectItem{{
 						Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `""`}}},
-				}}}},
-				&ast.ObjectItem{Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-					&ast.ObjectItem{
+						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `""`}},
+					}},
+				}},
+				&ast.ObjectType{List: &ast.ObjectList{
+					Items: []*ast.ObjectItem{{
 						Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"fizzbuzz"`}}},
-				}}}},
+						Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"fizzbuzz"`}},
+					}},
+				}},
 			}},
 		},
 		{
@@ -281,54 +287,51 @@ func TestEncodeMap(t *testing.T) {
 		{
 			ID: "keyed list",
 			Input: reflect.ValueOf(map[string][]map[string]interface{}{
-				"obj1": []map[string]interface{}{
-					map[string]interface{}{"foo": "bar"},
-					map[string]interface{}{"boo": "hoo"},
+				"obj1": {
+					{"foo": "bar"},
+					{"boo": "hoo"},
 				},
-				"obj2": []map[string]interface{}{
-					map[string]interface{}{"foo": "bar"},
-					map[string]interface{}{"boo": "hoo"},
+				"obj2": {
+					{"foo": "bar"},
+					{"boo": "hoo"},
 				},
 			}),
 			Expected: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
 				&ast.ObjectItem{
 					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj1"}}},
-					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-						&ast.ObjectItem{
-							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "boo"}}},
-							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"hoo"`}},
-						},
-					}}},
-				},
-				&ast.ObjectItem{
-					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj1"}}},
-					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-						&ast.ObjectItem{
-							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "foo"}}},
-							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"bar"`}},
-						},
-					}}},
-				},
-				&ast.ObjectItem{
-					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj2"}}},
-					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-						&ast.ObjectItem{
-							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "boo"}}},
-							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"hoo"`}},
-						},
-					}}},
+					Val: &ast.ListType{List: []ast.Node{
+						&ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+							{
+								Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "foo"}}},
+								Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"bar"`}},
+							},
+						}}},
+						&ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+							{
+								Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "boo"}}},
+								Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"hoo"`}},
+							},
+						}}},
+					}},
 				},
 				&ast.ObjectItem{
 					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "obj2"}}},
-					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-						&ast.ObjectItem{
-							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "foo"}}},
-							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"bar"`}},
-						},
-					}}},
+					Val: &ast.ListType{List: []ast.Node{
+						&ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+							{
+								Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "foo"}}},
+								Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"bar"`}},
+							},
+						}}},
+						&ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
+							{
+								Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "boo"}}},
+								Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"hoo"`}},
+							},
+						}}},
+					}},
 				},
-			}},
-			},
+			}}},
 		},
 	}
 
@@ -408,12 +411,14 @@ func TestEncodeStruct(t *testing.T) {
 			Expected: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
 				&ast.ObjectItem{
 					Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Foo"}}},
-					Val: &ast.ObjectType{List: &ast.ObjectList{Items: []*ast.ObjectItem{
-						&ast.ObjectItem{
-							Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
-							Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"Test"`}},
-						},
-					}}},
+					Val: &ast.ListType{List: []ast.Node{&ast.ObjectType{
+						List: &ast.ObjectList{
+							Items: []*ast.ObjectItem{{
+								Keys: []*ast.ObjectKey{{Token: token.Token{Type: token.IDENT, Text: "Bar"}}},
+								Val:  &ast.LiteralType{Token: token.Token{Type: token.STRING, Text: `"Test"`}},
+							}},
+						}}},
+					},
 				},
 			}}},
 		},


### PR DESCRIPTION
I raised the issue https://github.com/hashicorp/hcl/issues/269 thinking there was a bug in the HCL printer that was throwing an out of bounds exception when encoding nested arrays.

Upon debugging, I found that when decoding HCL with nested arrays via `hcl.decode`, the slices element in reflection was always `interface{}` rather than it's correct primitive type of `string` which caused it to be encoded as a block list rather than a primitive one. Upon printing, it would then panic since the block list had no keys.

Overall, this PR changes how an array of maps and slices are encoded to what I believe is more correct and gives more feature parity between the HCL decoder and this encoder. With this change, I can now decode and encode HCL files with them being correctly parsed by Terraform.

**Before:**
map array
```hcl
Foo = {
  bar = "buzz"
}

Foo = {
  buzz = "bar"
}
```

slices
```hcl
foo = "bar"
foo = "buzz"
```

**After:**
map array
```hcl
Foo = [
  {
    bar = "buzz"
  },
  {
    buzz = "bar"
  },
]
```
slices
```hcl
foo = [
  "bar",
  "buzz",
]
```

**Added Test**
The added test covers the printing of nested slices. Without the change in this PR, this test would cause the same exception as the linked issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rodaine/hclencoder/11)
<!-- Reviewable:end -->
