### PR TITLE
Make script/test more robust 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo:     false
 language: go
-go:       1.6
+go:       1.11
 
 install: go get -t ./...
 script:  ./script/test

--- a/nodes.go
+++ b/nodes.go
@@ -277,8 +277,8 @@ func encodeStruct(in reflect.Value) (ast.Node, []*ast.ObjectKey, error) {
 		itemKey := &ast.ObjectKey{Token: tkn}
 
 		// if the item is an object list, we need to flatten out the items
-		if val, ok := val.(*ast.ObjectList); ok {
-			for _, obj := range val.Items {
+		if objectList, ok := val.(*ast.ObjectList); ok {
+			for _, obj := range objectList.Items {
 				objectKeys := append([]*ast.ObjectKey{itemKey}, obj.Keys...)
 				list.Add(&ast.ObjectItem{
 					Keys: objectKeys,

--- a/script/test
+++ b/script/test
@@ -4,11 +4,16 @@ set -e
 echo "go fmt..."
 test -z "$(gofmt -l -w . | tee /dev/stderr)"
 
+if ! [ -x "$(command -v golint)" ]; then
+  echo "installing golint..."
+  go get -u golang.org/x/lint/golint
+fi
+
 echo "go lint..."
 test -z "$(golint ./... | tee /dev/stderr)"
 
 echo "go vet..."
-test -z "$(go tool vet -test . 2>&1 | tee /dev/stderr)"
+test -z "$(go tool vet -all -shadow . 2>&1 | tee /dev/stderr)"
 
 echo "go test..."
 go test -race -cover ./...


### PR DESCRIPTION
This makes the test-script more robust, e.g. when dealing with different golang versions or golint not installed ([e.g. in travis-ci](https://travis-ci.org/rodaine/hclencoder/builds/490696357#L456))

(originally suggested by @promiseofcake in #8)
