### PR TITLE
Encode multiline strings into heredoc format

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -335,6 +335,12 @@ func tokenize(in reflect.Value, ident bool) (t token.Token, err error) {
 		}, nil
 
 	case reflect.String:
+		if isMultiline(in.String()) {
+			return token.Token{
+				Type: token.IDENT,
+				Text: heredoc(in.String()),
+			}, nil
+		}
 		if ident {
 			return token.Token{
 				Type: token.IDENT,
@@ -425,4 +431,12 @@ func (ol objectItems) Less(i, j int) bool {
 		return iKeys[k].Token.Text < jKeys[k].Token.Text
 	}
 	return len(iKeys) <= len(jKeys)
+}
+
+func isMultiline(s string) bool {
+	return strings.Contains(s, "\n")
+}
+
+func heredoc(s string) string {
+	return fmt.Sprintf("<<EOF\n%s\nEOF", s)
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -496,6 +496,13 @@ func TestTokenize(t *testing.T) {
 			token.Token{Type: token.IDENT, Text: "fizzbuzz"},
 			false,
 		},
+		{
+			"string - multiline",
+			reflect.ValueOf("asdf\njkl;"),
+			false,
+			token.Token{Type: token.IDENT, Text: "<<EOF\nasdf\njkl;\nEOF"},
+			false,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This first pass does not allow one to override the `EOF` sentinel with an hcle tag. 

How can I add a tag that expects a value? The existing hcle meta fields are all bools. Should I support something like `hcle:"heredoc:EOF"` and use string parsing to pull `EOF` from the heredoc tag?

#15 