### PR TITLE
Add support for Nodes

### DIFF
--- a/_tests/basic.hcl
+++ b/_tests/basic.hcl
@@ -5,3 +5,5 @@ Int = 123
 Bool = true
 
 Float = 4.56
+
+Node = baz

--- a/_tests/nested-struct-slice-no-key.hcl
+++ b/_tests/nested-struct-slice-no-key.hcl
@@ -3,6 +3,9 @@ Widget = [
     Foo = "bar"
   },
   {
+    Bar = fizz
+  },
+  {
     Foo = "baz"
   },
 ]

--- a/_tests/nested-structs.hcl
+++ b/_tests/nested-structs.hcl
@@ -5,3 +5,8 @@ Foo {
 Fizz {
   Buzz = 1.23
 }
+
+Bar {
+  Bar  = baz
+  Fizz = "bar"
+}

--- a/hclencoder.go
+++ b/hclencoder.go
@@ -10,7 +10,7 @@ import (
 
 // Encode converts any supported type into the corresponding HCL format
 func Encode(in interface{}) ([]byte, error) {
-	node, _, err := encode(reflect.ValueOf(in))
+	node, _, err := encode(reflect.ValueOf(in), false)
 	if err != nil {
 		return nil, err
 	}

--- a/hclencoder_test.go
+++ b/hclencoder_test.go
@@ -29,11 +29,13 @@ func TestEncoder(t *testing.T) {
 				Int    int
 				Bool   bool
 				Float  float64
+				Node   string `hcle:"node"`
 			}{
 				"bar",
 				123,
 				true,
 				4.56,
+				"baz",
 			},
 			Output: "basic",
 		},
@@ -66,9 +68,17 @@ func TestEncoder(t *testing.T) {
 			Input: struct {
 				Foo  struct{ Bar string }
 				Fizz struct{ Buzz float64 }
+				Bar  struct {
+					Bar  string `hcle:"node"`
+					Fizz string
+				}
 			}{
 				struct{ Bar string }{Bar: "baz"},
 				struct{ Buzz float64 }{Buzz: 1.23},
+				struct {
+					Bar  string `hcle:"node"`
+					Fizz string
+				}{Bar: "baz", Fizz: "bar"},
 			},
 			Output: "nested-structs",
 		},
@@ -131,14 +141,17 @@ func TestEncoder(t *testing.T) {
 			ID: "nested struct slice no key",
 			Input: struct {
 				Widget []struct {
-					Foo string
+					Foo string `hcle:"omitempty"`
+					Bar string `hcle:"omitempty,node"`
 				}
 			}{
 				Widget: []struct {
-					Foo string
+					Foo string `hcle:"omitempty"`
+					Bar string `hcle:"omitempty,node"`
 				}{
-					{"bar"},
-					{"baz"},
+					{"bar", ""},
+					{"", "fizz"},
+					{"baz", ""},
 				},
 			},
 			Output: "nested-struct-slice-no-key",

--- a/readme.md
+++ b/readme.md
@@ -16,8 +16,9 @@ type Farmer struct {
 }
 
 type Animal struct {
-  Name  string `hcl:",key"`
-  Sound string `hcl:"says" hcle:"omitempty"`
+  Name     string `hcl:",key"`
+  Sound    string `hcl:"says" hcle:"omitempty"`
+  Category string `hcle:"node"`
 }
 
 type Config struct {
@@ -42,13 +43,16 @@ input := Config{
     {
       Name:  "cow",
       Sound: "moo",
+      Category: "data.animal_categories.cow"
     },
     {
       Name:  "pig",
       Sound: "oink",
+      Category: "data.animal_categories.pig"
     },
     {
       Name: "rock",
+      Category: "data.animal_categories.rock"
     },
   },
   Buildings: map[string]string{
@@ -81,13 +85,17 @@ fmt.Print(string(hcl))
 //
 // animal "cow" {
 //   says = "moo"
+//   category = data.animal_categories.cow
 // }
 //
 // animal "pig" {
 //   says = "oink"
+//   category = data.animal_categories.pig
 // }
 //
-// animal "rock" {}
+// animal "rock" {
+//   category = data.animal_categories.rock
+// }
 //
 // buildings {
 //   Barn  = "456 Digits Drive"
@@ -125,6 +133,8 @@ fmt.Print(string(hcl))
 - **`hcle:"omit"`** - omits this field from encoding into HCL. This is similar behavior to [`json:"-"`][json].
 
 - **`hcle:"omitempty"`** - omits this field if it is a zero value for its type. This is similar behavior to [`json:",omitempty"`][json].
+
+- **`hcle:"node"`** - node will omit quotes from the output, useful for references.
 
 [HCL]:         https://github.com/hashicorp/hcl
 [hclprinter]:  https://godoc.org/github.com/hashicorp/hcl/hcl/printer

--- a/script/test
+++ b/script/test
@@ -13,7 +13,7 @@ echo "go lint..."
 test -z "$(golint ./... | tee /dev/stderr)"
 
 echo "go vet..."
-test -z "$(go tool vet -all -shadow . 2>&1 | tee /dev/stderr)"
+test -z "$(go vet -all . 2>&1 | tee /dev/stderr)"
 
 echo "go test..."
 go test -race -cover ./...


### PR DESCRIPTION
This allows a consumer of `hclencoder` to work with direct references, as quoted references (`"${var.baz}"`) will be deprecated soon.

