### PR TITLE
Support "label" in hcl v2

### DIFF
--- a/nodes.go
+++ b/nodes.go
@@ -20,6 +20,8 @@ const (
 	// KeyTag indicates that the value of the field should be part of
 	// the parent object block's key, not a property of that block
 	KeyTag string = "key"
+	// LabelTag is an alias for KeyTag, hcl v2 has renamed key to label.
+	LabelTag string = "label"
 
 	// SquashTag is attached to anonymous fields of a struct and indicates
 	// to the encoder to lift the fields of that value into the parent
@@ -220,7 +222,7 @@ func encodeMap(in reflect.Value) (ast.Node, []*ast.ObjectKey, error) {
 }
 
 // encodeStruct converts a struct type into an ast.ObjectType. An ast.ObjectKey
-// may be returned if a KeyTag is present that should be used by a parent
+// may be returned if a KeyTag/LabelTag is present that should be used by a parent
 // ast.ObjectItem if this node is nested.
 func encodeStruct(in reflect.Value) (ast.Node, []*ast.ObjectKey, error) {
 	l := in.NumField()
@@ -367,7 +369,7 @@ func extractFieldMeta(f reflect.StructField) (meta fieldMeta) {
 
 		for _, tag := range tags[1:] {
 			switch tag {
-			case KeyTag:
+			case KeyTag, LabelTag:
 				meta.key = true
 			case SquashTag:
 				meta.squash = true

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -531,6 +531,10 @@ func TestExtractFieldMeta(t *testing.T) {
 			fieldMeta{name: "bar", key: true},
 		},
 		{
+			`hcl:"bar,label"`,
+			fieldMeta{name: "bar", key: true},
+		},
+		{
 			`hcl:",squash"`,
 			fieldMeta{name: fieldName, squash: true},
 		},


### PR DESCRIPTION
In my hcl v2 support story, it additionally looks like `key` is now `label`.
When trying to use a struct for the in and out, using `label` for reading works in hcl v2, but hclencoder doesn't speak it. This PR allows it to see `label` as an alias for `key`.

Paired with https://github.com/rodaine/hclencoder/pull/19 it brings hclencoder one step closer to compatibility with hcl v2.